### PR TITLE
🛟 Arrumador: Configure tooling and CI

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -33,6 +33,7 @@ jobs:
           title: "chore: update codegen"
           body: "Automated PR from codegen updates."
           branch: "chore/update-codegen"
+          base: ${{ github.head_ref || github.ref_name }}
 
       - name: CI
         run: mise run ci

--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install mise
         uses: jdx/mise-action@v2
         with:
-          version: 2024.1.1 # Pinning mise version
+          version: 2025.2.3 # Pinning mise version
           install: true
 
       - name: Install

--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -1,0 +1,38 @@
+name: autorelease
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  autorelease:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install mise
+        uses: jdx/mise-action@v2
+        with:
+          version: 2024.1.1 # Pinning mise version
+          install: true
+
+      - name: Install
+        run: mise run install
+
+      - name: Codegen
+        run: mise run codegen
+
+      - name: PR if Difference
+        id: create_pr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update codegen"
+          title: "chore: update codegen"
+          body: "Automated PR from codegen updates."
+          branch: "chore/update-codegen"
+
+      - name: CI
+        run: mise run ci

--- a/mise.toml
+++ b/mise.toml
@@ -20,6 +20,9 @@ run = "workspaced codebase format"
 [tasks.test]
 depends = ["test:*"]
 
+[tasks."codegen:dummy"]
+run = "echo 'No codegen step'"
+
 [tasks.codegen]
 depends = ["codegen:*"]
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,27 @@
+[tools]
+node = "20.19.0"
+"ubi:lucasew/workspaced" = "latest"
+
+[tasks."install:npm"]
+run = "npm install"
+
+[tasks."test:npm"]
+run = "npm run test"
+
+[tasks.install]
+depends = ["install:*"]
+
+[tasks.lint]
+run = "workspaced codebase lint"
+
+[tasks.fmt]
+run = "workspaced codebase format"
+
+[tasks.test]
+depends = ["test:*"]
+
+[tasks.codegen]
+depends = ["codegen:*"]
+
+[tasks.ci]
+depends = ["lint", "test"]


### PR DESCRIPTION
Adds `mise.toml` to configure `lint`, `fmt`, `test`, `codegen`, `install`, `ci` tasks using `workspaced` and `npm`. Creates `.github/workflows/autorelease.yml` according to the requested execution flow for a Vercel-deployed project (without release/artifacts steps).

---
*PR created automatically by Jules for task [6207778124547964216](https://jules.google.com/task/6207778124547964216) started by @lucasew*