### PR TITLE
🧹 Janitor: Fix optional property access and input label a11y

### DIFF
--- a/.jules/janitor.md
+++ b/.jules/janitor.md
@@ -1,0 +1,1 @@
+- 2026-03-09: Fixed undefined optional chain property access and missing accessibility attributes on form labels.

--- a/src/components/Decision.svelte
+++ b/src/components/Decision.svelte
@@ -54,7 +54,7 @@
         if (!tree?.alternatives && route.length > 0) {
             return null
         }
-        const node = tree?.alternatives[route[0]] || null
+        const node = tree?.alternatives?.[route[0]] || null
         return resolveNode(node, route.slice(1))
     }
 

--- a/src/components/DecisionTreeInput.svelte
+++ b/src/components/DecisionTreeInput.svelte
@@ -66,7 +66,7 @@ function setupDummyState() {
                 placeholder="https://exemplo.com/tree.json ou base64..."
                 class="input input-bordered input-lg w-full text-base"
             />
-            <label class="label">
+            <label class="label" for="tree-url">
                 <span class="label-text-alt text-base-content/60">
                     Cole uma URL ou JSON codificado em base64
                 </span>


### PR DESCRIPTION
### What Changed
- `src/components/Decision.svelte`: Added optional chaining (`?.[route[0]]`) to properly handle cases where `tree.alternatives` is optionally undefined.
- `src/components/DecisionTreeInput.svelte`: Added `for="tree-url"` to correctly associate the form label with the input control.
- `.jules/janitor.md`: Appended a journal entry for the cleanup pass.

### Why This Helps
- Fixes `svelte-check` compilation errors and strict mode type issues.
- Improves accessibility (A11y) and resolves compiler warnings regarding unassociated labels.

### Before/After
- Before: `tree?.alternatives[route[0]]` resulted in a TypeScript "possibly undefined" error. The label for the input lacked a `for` attribute, causing an A11y warning.
- After: Types are correctly handled via optional chaining, and the label is explicitly associated with its input. The `svelte-check` build passes with 0 errors and 0 warnings.

### Verification
- Ran `npm run check` and verified zero errors and warnings.
- Ran `npm run test` and verified the smoke tests continue to pass.
- Verified visual output via Playwright.

### Assumptions
- The `tree.alternatives` can indeed be undefined, and defaulting to `null` is the intended behavior.
- The `for` attribute in `DecisionTreeInput.svelte` should point to `tree-url` which is the ID of the adjacent input.

### Alternatives Not Chosen
- Skipping the A11y warning since it was a warning rather than a compilation failure. Chosen to fix it as it's a quick win.
- Wrapping the `alternatives` access in an explicit `if` check. Optional chaining is more concise and idiomatic.

### How To Pivot
- If the label should not be associated with `tree-url`, remove the `for` attribute or assign it a different ID.
- If `tree.alternatives` should never be undefined at that point, the types in `Model.ts` should be updated to make it non-optional.

### Next Knobs
- `src/components/Decision.svelte`
- `src/components/DecisionTreeInput.svelte`

---
*PR created automatically by Jules for task [751552934272312514](https://jules.google.com/task/751552934272312514) started by @lucasew*