### PR TITLE
📝 Docs: Document core models and decision tree components

### DIFF
--- a/src/Model.ts
+++ b/src/Model.ts
@@ -1,12 +1,33 @@
+/**
+ * Represents a single node or a complete, recursively branched decision tree.
+ * The tree is navigated by rendering `title` and `description`, then
+ * prompting the user to select from the `alternatives`.
+ */
 export interface DecisionTree {
+    /** The primary heading displayed to the user for this decision node. */
     title: i18Led
+    /** Optional secondary context or detailed explanation for this node. */
     description?: i18Led
+    /**
+     * Key-value mapping of subsequent paths.
+     * The keys dictate URL segments for navigation, and values provide the next DecisionTree state.
+     */
     alternatives?: Record<string, DecisionTree>
 }
 
+/**
+ * A translatable string payload.
+ * Can be a raw string (no localization) or a dictionary mapping locale keys (e.g. `en_US`, `pt_BR`) to text.
+ */
 export type i18Led = Record<string, string> | string
 
-
+/**
+ * Resolves localized text based on the user's browser language.
+ * Falls back to the first available translation or an empty string if the exact locale isn't found.
+ *
+ * @param txt - The polymorphic string payload to resolve.
+ * @returns The resolved text suitable for rendering.
+ */
 export function i18nGet(txt: i18Led): string {
     if (typeof txt === 'string') {
         return txt;

--- a/src/components/Decision.svelte
+++ b/src/components/Decision.svelte
@@ -1,4 +1,9 @@
 <script lang="ts">
+    /**
+     * Render container for an active `DecisionTree`.
+     * Manages browser history interceptors to translate path segments (like `/a/b`)
+     * into recursive descents through the tree structure without full page reloads.
+     */
     import Markdown from './Markdown.svelte';
     import i18n from '../i18n';
     import type {DecisionTree} from "../Model";
@@ -44,6 +49,14 @@
         };
     });
 
+    /**
+     * Recursively walks down the decision tree according to the ordered path segments from the URL.
+     * Returns `null` if the route is invalid or overshoots the available alternatives.
+     *
+     * @param tree - The root or current subset of the tree.
+     * @param route - Remaining URL path fragments to traverse.
+     * @returns The resolved descendant node, or `null` if resolution fails.
+     */
     function resolveNode(tree: DecisionTree | null, route: string[]): DecisionTree | null {
         if (!tree) {
             return null

--- a/src/components/DecisionTree.svelte
+++ b/src/components/DecisionTree.svelte
@@ -1,4 +1,10 @@
 <script lang="ts">
+/**
+ * Root orchestrator component for the application.
+ * Bootstraps the `DecisionTree` state based on URL search parameters.
+ * When the tree is loaded successfully, it dynamically swaps the UI
+ * between the `DecisionTreeInput` (when uninitialized) and the `Decision` view.
+ */
 import type {DecisionTree} from "../Model";
 import { i18nGet } from "../Model";
 import DecisionTreeInput from "./DecisionTreeInput.svelte";
@@ -6,6 +12,13 @@ import Decision from "../components/Decision.svelte";
 import DecisionReset from "../components/DecisionReset.svelte";
 import i18n from "../i18n";
 
+/**
+ * Attempts to parse the decision tree payload from the `?tree=` query param.
+ * Differentiates between a remote source to be fetched and inline base64 data.
+ *
+ * @param url - The fully qualified active URL payload.
+ * @returns The parsed DecisionTree structure, or null if no parameter exists.
+ */
 async function getDecisionTreeFromURL(url: URL): Promise<DecisionTree | null> {
     const tree = url.searchParams.get("tree")
     if (tree == null) {

--- a/src/components/DecisionTreeInput.svelte
+++ b/src/components/DecisionTreeInput.svelte
@@ -1,14 +1,23 @@
 <script lang="ts">
+/**
+ * Uninitialized application view.
+ * Collects a URL or base64 string from the user, updating the search parameters
+ * so the parent orchestration component (`DecisionTree`) can fetch and mount the state.
+ */
 import i18n from "../i18n";
 import type { DecisionTree } from "../Model";
 import { i18nGet } from "../Model";
 
 let url = $state("")
+
+/** Update history state to prompt initialization of the provided Tree URL or Base64 payload. */
 function handleClick() {
     let u = new URL(window.location.href)
     u.searchParams.set('tree', url)
     window.history.pushState({}, '', u)
 }
+
+/** Mounts an interactive demonstration of a structured decision node with localization and markdown. */
 function setupDummyState() {
     const dummyState: DecisionTree = {
         title: "Teste **eoq** trabson",

--- a/src/components/Markdown.svelte
+++ b/src/components/Markdown.svelte
@@ -1,4 +1,9 @@
 <script lang="ts">
+    /**
+     * Markdown-to-HTML UI renderer.
+     * Sanitizes external output locally before injection into the DOM,
+     * protecting against persistent cross-site scripting (XSS) via dynamic titles/descriptions.
+     */
     import { marked } from 'marked';
     import DOMPurify from 'isomorphic-dompurify';
 

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,5 +1,10 @@
 import type { i18Led } from "./Model";
 
+/**
+ * Global application localization dictionary.
+ * Used for static labels across the UI components, as distinct from
+ * the user-provided translation blobs inside `DecisionTree` structures.
+ */
 let i18n: Record<string,i18Led> = {
     loading: {
         'en_US': "Loading...",


### PR DESCRIPTION
This PR improves the codebase documentation by adding non-obvious JSDoc/TSDoc explanations to the core application models (`DecisionTree`, `i18Led`, `i18nGet`) and the Svelte components (`DecisionTree`, `Decision`, `DecisionTreeInput`, `Markdown`).

### Assumptions
- The primary role of `DecisionTree` is to act as the root orchestrator, determining which child view to render based on URL parameter presence.
- The `i18nGet` function gracefully falls back to the first available dictionary key if the exact navigator locale isn't present.
- The Markdown component's `isomorphic-dompurify` integration is explicitly designed to prevent XSS attacks when rendering dynamic string output.

### Alternatives Not Chosen
- Skipping component documentation entirely in favor of a centralized `README` or architecture document. Inline JSDocs were preferred to improve immediate developer onboarding and IDE intellisense.
- Documenting getters and setters or redundant typing information was avoided to strictly follow the essentialism philosophy.

### How To Pivot
- If the documentation is too verbose, you can manually strip the JSDocs from the Svelte files and retain them only in `src/Model.ts`. The `git diff` makes identifying the blocks straightforward since no executable code was changed.

### Next Knobs
- **`src/Model.ts`**: Tweak the documentation of the `alternatives` object if the URL path segment mapping strategy changes.
- **`src/i18n.ts`**: Update the global dictionary context if the project pivots to using a dedicated localization library (e.g. `svelte-i18n`) instead of the current manual setup.
- **`src/components/Markdown.svelte`**: Expand the documentation on marked options if custom rendering logic is introduced.

---
*PR created automatically by Jules for task [16209201053094182403](https://jules.google.com/task/16209201053094182403) started by @lucasew*