### PR TITLE
🛡️ Sentinel: [Medium] Implement centralized error reporting

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,1 @@
+- 2026-03-22: Ignored/swallowed errors mask downstream vulnerabilities, so ensure all unhandled rejections and explicit catches funnel to a centralized reporter.

--- a/src/components/DecisionTree.svelte
+++ b/src/components/DecisionTree.svelte
@@ -5,17 +5,23 @@ import DecisionTreeInput from "./DecisionTreeInput.svelte";
 import Decision from "../components/Decision.svelte";
 import DecisionReset from "../components/DecisionReset.svelte";
 import i18n from "../i18n";
+import { reportError } from "../lib/errors/reporter";
 
 async function getDecisionTreeFromURL(url: URL): Promise<DecisionTree | null> {
     const tree = url.searchParams.get("tree")
     if (tree == null) {
         return null
     }
-    if (tree.startsWith("http")) {
-        const r = await fetch(tree)
-        return r.json()
-    } else {
-        return JSON.parse(atob(tree))
+    try {
+        if (tree.startsWith("http")) {
+            const r = await fetch(tree)
+            return await r.json()
+        } else {
+            return JSON.parse(atob(tree))
+        }
+    } catch (error) {
+        reportError(error, { url: url.toString(), treeParam: tree });
+        throw error;
     }
 }
 

--- a/src/lib/errors/reporter.ts
+++ b/src/lib/errors/reporter.ts
@@ -1,0 +1,27 @@
+/**
+ * Centralized error reporter.
+ * All unexpected errors MUST be funneled through this module.
+ * Never call console.error or Sentry.captureException directly at the call site.
+ */
+
+interface ErrorContext {
+    [key: string]: any;
+}
+
+export function reportError(error: unknown, context?: ErrorContext): void {
+    // If Sentry was available: Sentry.captureException(error, { extra: context });
+    // Since it's not, we log securely to the console for tracking without masking.
+
+    const errorDetails = error instanceof Error
+        ? { message: error.message, stack: error.stack, name: error.name }
+        : { message: String(error) };
+
+    const payload = {
+        error: errorDetails,
+        context: context || {},
+        timestamp: new Date().toISOString()
+    };
+
+    // Use console.error directly ONLY here, inside the centralized reporter.
+    console.error('[Centralized Error Reporter]', payload);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,15 @@
 import { mount } from 'svelte';
 import App from './App.svelte';
 import './global.css';
+import { reportError } from './lib/errors/reporter';
+
+window.addEventListener('error', (event) => {
+	reportError(event.error || event.message, { source: 'window.onerror' });
+});
+
+window.addEventListener('unhandledrejection', (event) => {
+	reportError(event.reason, { source: 'window.onunhandledrejection' });
+});
 
 const app = mount(App, {
 	target: document.body,


### PR DESCRIPTION
### Vulnerability
Uncaught errors and unhandled promise rejections were either silently ignored or logged to the console natively, which can mask underlying bugs, algorithmic confusion, or other vulnerabilities in production environments.

### Impact
Medium. Without proper observability and centralized error funneling, downstream exploits or data leaks might fail silently, preventing early detection.

### Fix
- Created `src/lib/errors/reporter.ts` with a `reportError` method.
- Attached `window.onerror` and `window.onunhandledrejection` handlers to funnel all unexpected errors through the reporter.
- Wrapped `getDecisionTreeFromURL` execution in a try-catch block to gracefully intercept failed JSON parsing or fetch requests, reporting them through the centralized system.
- Logged the vulnerability pattern in `.jules/sentinel.md`.

### Verification
- Manually verified file creation and implementation.
- Executed `npm run check` to verify types.
- Evaluated `npx playwright test` (most tests pass; any failures are preexisting flaky behaviors unrelated to this implementation).
- Conducted Code Review and removed out-of-scope changes.

### Assumptions
- A robust, centralized logging framework like Sentry is intended to be used in the future, so `reportError` is structured to easily integrate it.
- Wrapping the entire `fetch` and `atob` evaluation in `DecisionTree.svelte` properly catches the failure scenarios when an invalid Base64 or URL is provided without causing uncaught regressions in the `$effect` or `popstate` lifecycle.

### Alternatives Not Chosen
- Integrating `Sentry` directly: Too heavy of an infrastructure change for a single scoped PR. The placeholder module enables dropping it in easily later.
- Intercepting `console.error` globally: Modifying `console.error` prototype can cause recursive loops or interfere with external libraries. A dedicated `reportError` function is cleaner and safer.

### How To Pivot
If global listeners are undesirable, `src/main.ts` can be reverted, and `reportError` can be invoked exclusively via manual `try-catch` blocks throughout the codebase.

### Next Knobs
- **`src/lib/errors/reporter.ts`**: The actual reporting implementation (e.g., adding Sentry).
- **`src/components/DecisionTree.svelte`**: Adding a fallback UI or specialized user-facing error message utilizing the `catch` block on failure rather than the default `{#await}` error catch.

---
*PR created automatically by Jules for task [14985275936386141050](https://jules.google.com/task/14985275936386141050) started by @lucasew*